### PR TITLE
Multiple tokens per interest

### DIFF
--- a/lib/ExpoRegistrar.php
+++ b/lib/ExpoRegistrar.php
@@ -79,10 +79,18 @@ class ExpoRegistrar
         $tokens = [];
 
         foreach ($interests as $interest) {
-            $token = $this->repository->retrieve($interest);
+            $retrieved = $this->repository->retrieve($interest);
 
-            if (!is_null($token)) {
-                $tokens[] = $token;
+            if (!is_null($retrieved)) {
+                if(is_string($retrieved)) {
+                    $tokens[] = $retrieved;
+                }
+
+                if(is_array($retrieved)) {
+                    foreach($retrieved as $token) {
+                        $tokens[] = $token;
+                    }
+                }
             }
         }
 

--- a/lib/ExpoRegistrar.php
+++ b/lib/ExpoRegistrar.php
@@ -88,7 +88,9 @@ class ExpoRegistrar
 
                 if(is_array($retrieved)) {
                     foreach($retrieved as $token) {
-                        $tokens[] = $token;
+                        if(is_string($token)) {
+                            $tokens[] = $token;
+                        }
                     }
                 }
             }

--- a/lib/ExpoRepository.php
+++ b/lib/ExpoRepository.php
@@ -18,7 +18,7 @@ interface ExpoRepository
      *
      * @param string $key
      *
-     * @return string|null
+     * @return array|string|null
      */
     public function retrieve(string $key);
 

--- a/lib/Repositories/ExpoFileDriver.php
+++ b/lib/Repositories/ExpoFileDriver.php
@@ -32,7 +32,23 @@ class ExpoFileDriver implements ExpoRepository
             $storageInstance = $this->createFile();
         }
 
-        $storageInstance->{$key} = $value;
+        // Check for existing tokens
+        if(isset($storageInstance->{$key}))
+        {
+            // If there is a single token, make it an array so we can push the additional tokens in it
+            if(!is_array($storageInstance->{$key}))
+            {
+                $storageInstance->{$key} = [$storageInstance->{$key}];
+            }
+
+            // Add new token to existing key
+            array_push($storageInstance->{$key}, $value);
+        }
+        else
+        {
+            // First token for this key
+            $storageInstance->{$key} = [$value];
+        }
 
         $file = $this->updateRepository($storageInstance);
 
@@ -44,7 +60,7 @@ class ExpoFileDriver implements ExpoRepository
      *
      * @param string $key
      *
-     * @return string|null
+     * @return array|string|null
      */
     public function retrieve(string $key)
     {


### PR DESCRIPTION
Allow the retrieved result of the repository to be an **array**, string or null and handle this result accordingly to create an correct array of tokens.