### PR TITLE
The condition of Prevent duplicates should use in_array instead.

### DIFF
--- a/lib/Repositories/ExpoFileDriver.php
+++ b/lib/Repositories/ExpoFileDriver.php
@@ -40,7 +40,7 @@ class ExpoFileDriver implements ExpoRepository
             }
 
             // Prevent duplicates
-            if (!array_search($value, $storageInstance->{$key})) {
+            if (!in_array($value, $storageInstance->{$key})) {
                 // Add new token to existing key
                 array_push($storageInstance->{$key}, $value);
             }


### PR DESCRIPTION
<img width="1231" alt="2018-10-09 10 00 04" src="https://user-images.githubusercontent.com/35715664/46674454-c31f0a80-cc0e-11e8-8da7-db3fb6acdb0d.png">

When using array_search for prevent duplicates, it won't work as expected.
Because array_search will return the first match key of an array, if the duplicate value is at the 0 position of an array, it will push the same value(token) to tokens as well.

The better solution to the problem is change array_search into in_array.