### PR TITLE
Support for sending notifications to more than 100 users per interest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-    "name": "alymosul/exponent-server-sdk-php",
+    "name": "firzenizer/exponent-server-sdk-php",
     "description": "Server-side library for working with Expo push notifications using PHP",
     "keywords": ["expo", "exponent", "push", "notifications"],
     "type": "library",
     "license": "MIT",
     "authors": [
         {
-            "name": "Aly Suleiman",
-            "email": "alymosul@gmail.com"
+            "name": "Tomi Ruusala",
+            "email": "tomi.ruusala@gmail.com"
         }
     ],
     "require": {


### PR DESCRIPTION
This fork allows to send notifications for more than 100 users per interest. Expo notification API has limit of 100 notifications per request. 
https://docs.expo.io/versions/latest/guides/push-notifications#sending-notifications

This fork will create batches of 100 notifications and send them out.