### PR TITLE
array_search should never be used with a `!`

### DIFF
--- a/lib/Repositories/ExpoFileDriver.php
+++ b/lib/Repositories/ExpoFileDriver.php
@@ -110,7 +110,7 @@ class ExpoFileDriver implements ExpoRepository
 
                 $this->updateRepository($storageInstance);
 
-                return !array_search($value, $storageInstance->{$key});
+                return !in_array($value, $storageInstance->{$key});
             }
         } else {
             // Delete all tokens with this key


### PR DESCRIPTION
If `array_search` finds an element on the first index (which is *zero*), it will return a *zero*. `!0` evaluates to `true`, which is not what You want here. Replace it with `in_array`, just as You did in the `ExpoFileDriver@store` method.