### PR TITLE
Allowing custom storage file path

### DIFF
--- a/lib/Repositories/ExpoFileDriver.php
+++ b/lib/Repositories/ExpoFileDriver.php
@@ -170,10 +170,10 @@ class ExpoFileDriver implements ExpoRepository
     /**
      * Allows for custom token storage path
      *
-     * @param  string $path path to token storage json file
+     * @param  string $storage path to token storage json file
      * @return self
      */
-    public function setStorage(string $path): self
+    public function setStorage(string $storage): self
     {
         $this->storage = $storage;
         return $this;

--- a/lib/Repositories/ExpoFileDriver.php
+++ b/lib/Repositories/ExpoFileDriver.php
@@ -166,4 +166,16 @@ class ExpoFileDriver implements ExpoRepository
         fclose($file);
         return json_decode('{}');
     }
+
+    /**
+     * Allows for custom token storage path
+     *
+     * @param  string $path path to token storage json file
+     * @return self
+     */
+    public function setStorage(string $path): self
+    {
+        $this->storage = $storage;
+        return $this;
+    }
 }


### PR DESCRIPTION
PR allows for setting a custom token storage files. Very useful in scenarios where vendor dir is not writable.

Instead of using `Expo::normalSetup()` one would get an instance via
```php
$driver = new ExpoFileDriver();
$driver->setStorage('/my/custom/storage/path.json');
$expo = new Expo(new ExpoRegistrar($driver));
```