### PR TITLE
Fix error with empty response

### DIFF
--- a/lib/Expo.php
+++ b/lib/Expo.php
@@ -200,7 +200,7 @@ class Expo
             'status_code' => curl_getinfo($ch, CURLINFO_HTTP_CODE)
         ];
 
-        $responseData = json_decode($response['body'], true)['data'];
+        $responseData = json_decode($response['body'], true)['data'] ?? null;
 
         if (! is_array($responseData)) {
             throw new UnexpectedResponseException();


### PR DESCRIPTION
Error was “Undefined index: data”

We had a new error message after #37 was merged :

> Undefined index: data

This PR fixes this issue.