### PR TITLE
Improving unexpected exception message

### DIFF
--- a/lib/Expo.php
+++ b/lib/Expo.php
@@ -161,6 +161,23 @@ class Expo
     }
 
     /**
+     * Handle with unexpected response error
+     *
+     * @throws UnexpectedResponseException
+     *
+     * @return null|resource
+     */
+    private function handleWithUnexpectedResponse($response) {
+        if (is_array($response) && isset($response['body'])) {
+            $errors = json_decode($response['body'])->errors ?? [];
+
+            return $errors[0]->message ?? null;
+        }
+
+        return null;
+    }
+
+    /**
      * Get the cURL resource
      *
      * @throws ExpoException
@@ -199,7 +216,9 @@ class Expo
         $responseData = json_decode($response['body'], true)['data'] ?? null;
 
         if (! is_array($responseData)) {
-            throw new UnexpectedResponseException();
+            throw new UnexpectedResponseException(
+                $this->handleWithUnexpectedResponse($response)
+            );
         }
 
         return $responseData;


### PR DESCRIPTION
Getting the first message returned to make the error exception more clear

In response of issue 31: https://github.com/Alymosul/exponent-server-sdk-php/issues/31