### PR TITLE
Support for additional security access token

### DIFF
--- a/lib/Expo.php
+++ b/lib/Expo.php
@@ -82,7 +82,7 @@ class Expo
     /**
      * @param string|null $accessToken
      */
-    public function setAccessToken(?string $accessToken = null) {
+    public function setAccessToken(string $accessToken = null) {
         $this->accessToken = $accessToken;
     }
 
@@ -166,7 +166,7 @@ class Expo
         ];
 
         if ($this->accessToken) {
-            $headers []= sprintf('authorization: bearer %1$s', $this->accessToken);
+            $headers[] = sprintf('Authorization: Bearer %s', $this->accessToken);
         }
 
         // Set cURL opts

--- a/lib/Expo.php
+++ b/lib/Expo.php
@@ -26,6 +26,11 @@ class Expo
      * @var ExpoRegistrar
      */
     private $registrar;
+    
+    /** 
+     * @var string|null
+     */
+    private $accessToken = null;
 
     /**
      * Expo constructor.
@@ -72,6 +77,13 @@ class Expo
     public function unsubscribe($interest, $token = null)
     {
         return $this->registrar->removeInterest($interest, $token);
+    }
+    
+    /**
+     * @param string|null $accessToken
+     */
+    public function setAccessToken(?string $accessToken = null) {
+        $this->accessToken = $accessToken;
     }
 
     /**
@@ -148,12 +160,18 @@ class Expo
     {
         $ch = $this->getCurl();
 
+        $headers = [
+                'accept: application/json',
+                'content-type: application/json',
+        ];
+
+        if ($this->accessToken) {
+            $headers []= sprintf('authorization: bearer %1$s', $this->accessToken);
+        }
+
         // Set cURL opts
         curl_setopt($ch, CURLOPT_URL, self::EXPO_API_URL);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, [
-            'accept: application/json',
-            'content-type: application/json',
-        ]);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 


### PR DESCRIPTION
I needed to set up an "access token", as described in Expo official documentation here: https://docs.expo.io/push-notifications/sending-notifications/#additional-security

Since I couldn't find a way to have it with this library's original code, I have overridden Expo class with my own. These are the changes I did.