### PR TITLE
Ensures that a valid json is returned in the tokens.json file

### DIFF
--- a/lib/Repositories/ExpoFileDriver.php
+++ b/lib/Repositories/ExpoFileDriver.php
@@ -138,7 +138,15 @@ class ExpoFileDriver implements ExpoRepository
         }
 
         $file = file_get_contents($this->storage);
-        return json_decode($file);
+
+        // It guarantees that it will not have an unexpected value in the file's contents. Ex: null
+        $json = json_decode($file);
+
+        if (gettype($json) != 'object') {
+            $json = json_decode('{}');
+        }
+
+        return $json;
     }
 
     /**

--- a/lib/Repositories/ExpoFileDriver.php
+++ b/lib/Repositories/ExpoFileDriver.php
@@ -139,7 +139,7 @@ class ExpoFileDriver implements ExpoRepository
 
         $file = file_get_contents($this->storage);
 
-        // It guarantees that it will not have an unexpected value in the file's contents. Ex: null
+        // Ensures that it will not have an unexpected value in the contents of the tokens.json file. Ex: null
         $json = json_decode($file);
 
         if (gettype($json) != 'object') {


### PR DESCRIPTION
I couldn't find the reason, but sometimes my tokens.json file had 'null' content. This ended up generating an exception when calling the 'subscribe' method. With this change the exception no longer occurred.