### PR TITLE
feat: encode multibyte Unicode characters literally

### DIFF
--- a/lib/Expo.php
+++ b/lib/Expo.php
@@ -115,7 +115,7 @@ class Expo
 
         $ch = $this->prepareCurl();
 
-        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($postData));
+        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($postData, JSON_UNESCAPED_UNICODE));
 
         $response = $this->executeCurl($ch);
 


### PR DESCRIPTION
Fix the issue with changing special symbols to Unicode.
Example:
What we send: `"body": "Swann’s Terrace"`
What we get in a push notification: `Swann\\u2019s Terrace `